### PR TITLE
added themes from Atelier-Schemes

### DIFF
--- a/styles/atelier-cave-dark.css
+++ b/styles/atelier-cave-dark.css
@@ -1,0 +1,160 @@
+/* Atelier Cave Dark by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave) */
+
+/* plain text */
+.pln {
+  color: #efecf4;
+}
+
+@media screen {
+  /* string content */
+  .str {
+    color: #2a9292;
+  }
+
+  /* a keyword */
+  .kwd {
+    color: #955ae7;
+  }
+
+  /* a comment */
+  .com {
+    color: #655f6d;
+  }
+
+  /* a type name */
+  .typ {
+    color: #576ddb;
+  }
+
+  /* a literal value */
+  .lit {
+    color: #aa573c;
+  }
+
+  /* punctuation */
+  .pun {
+    color: #efecf4;
+  }
+
+  /* lisp open bracket */
+  .opn {
+    color: #efecf4;
+  }
+
+  /* lisp close bracket */
+  .clo {
+    color: #efecf4;
+  }
+
+  /* a markup tag name */
+  .tag {
+    color: #be4678;
+  }
+
+  /* a markup attribute name */
+  .atn {
+    color: #aa573c;
+  }
+
+  /* a markup attribute value */
+  .atv {
+    color: #398bc6;
+  }
+
+  /* a declaration */
+  .dec {
+    color: #aa573c;
+  }
+
+  /* a variable name */
+  .var {
+    color: #be4678;
+  }
+
+  /* a function name */
+  .fun {
+    color: #576ddb;
+  }
+}
+/* Use higher contrast and text-weight for printable form. */
+@media print, projection {
+  .str {
+    color: #006600;
+  }
+
+  .kwd {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .com {
+    color: #600;
+    font-style: italic;
+  }
+
+  .typ {
+    color: #404;
+    font-weight: bold;
+  }
+
+  .lit {
+    color: #004444;
+  }
+
+  .pun, .opn, .clo {
+    color: #444400;
+  }
+
+  .tag {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .atn {
+    color: #440044;
+  }
+
+  .atv {
+    color: #006600;
+  }
+}
+/* Style */
+pre.prettyprint {
+  background: #19171c;
+  color: #585260;
+  font-family: Consolas, Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  border: 1px solid #19171c;
+  padding: 10px;
+  border-radius: 3px;
+}
+
+/* Specify class=linenums on a pre to get line numbering */
+ol.linenums {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* IE indents via margin-left */
+li.L0,
+li.L1,
+li.L2,
+li.L3,
+li.L4,
+li.L5,
+li.L6,
+li.L7,
+li.L8,
+li.L9 {
+  /* */
+}
+
+/* Alternate shading for lines */
+li.L1,
+li.L3,
+li.L5,
+li.L7,
+li.L9 {
+  /* */
+}

--- a/styles/atelier-cave-light.css
+++ b/styles/atelier-cave-light.css
@@ -1,0 +1,160 @@
+/* Atelier Cave Light by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave) */
+
+/* plain text */
+.pln {
+  color: #19171c;
+}
+
+@media screen {
+  /* string content */
+  .str {
+    color: #2a9292;
+  }
+
+  /* a keyword */
+  .kwd {
+    color: #955ae7;
+  }
+
+  /* a comment */
+  .com {
+    color: #7e7887;
+  }
+
+  /* a type name */
+  .typ {
+    color: #576ddb;
+  }
+
+  /* a literal value */
+  .lit {
+    color: #aa573c;
+  }
+
+  /* punctuation */
+  .pun {
+    color: #19171c;
+  }
+
+  /* lisp open bracket */
+  .opn {
+    color: #19171c;
+  }
+
+  /* lisp close bracket */
+  .clo {
+    color: #19171c;
+  }
+
+  /* a markup tag name */
+  .tag {
+    color: #be4678;
+  }
+
+  /* a markup attribute name */
+  .atn {
+    color: #aa573c;
+  }
+
+  /* a markup attribute value */
+  .atv {
+    color: #398bc6;
+  }
+
+  /* a declaration */
+  .dec {
+    color: #aa573c;
+  }
+
+  /* a variable name */
+  .var {
+    color: #be4678;
+  }
+
+  /* a function name */
+  .fun {
+    color: #576ddb;
+  }
+}
+/* Use higher contrast and text-weight for printable form. */
+@media print, projection {
+  .str {
+    color: #006600;
+  }
+
+  .kwd {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .com {
+    color: #600;
+    font-style: italic;
+  }
+
+  .typ {
+    color: #404;
+    font-weight: bold;
+  }
+
+  .lit {
+    color: #004444;
+  }
+
+  .pun, .opn, .clo {
+    color: #444400;
+  }
+
+  .tag {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .atn {
+    color: #440044;
+  }
+
+  .atv {
+    color: #006600;
+  }
+}
+/* Style */
+pre.prettyprint {
+  background: #efecf4;
+  color: #8b8792;
+  font-family: Consolas, Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  border: 1px solid #e2dfe7;
+  padding: 10px;
+  border-radius: 3px;
+}
+
+/* Specify class=linenums on a pre to get line numbering */
+ol.linenums {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* IE indents via margin-left */
+li.L0,
+li.L1,
+li.L2,
+li.L3,
+li.L4,
+li.L5,
+li.L6,
+li.L7,
+li.L8,
+li.L9 {
+  /* */
+}
+
+/* Alternate shading for lines */
+li.L1,
+li.L3,
+li.L5,
+li.L7,
+li.L9 {
+  /* */
+}

--- a/styles/atelier-dune-dark.css
+++ b/styles/atelier-dune-dark.css
@@ -1,0 +1,160 @@
+/* Atelier Dune Dark by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/dune) */
+
+/* plain text */
+.pln {
+  color: #fefbec;
+}
+
+@media screen {
+  /* string content */
+  .str {
+    color: #60ac39;
+  }
+
+  /* a keyword */
+  .kwd {
+    color: #b854d4;
+  }
+
+  /* a comment */
+  .com {
+    color: #7d7a68;
+  }
+
+  /* a type name */
+  .typ {
+    color: #6684e1;
+  }
+
+  /* a literal value */
+  .lit {
+    color: #b65611;
+  }
+
+  /* punctuation */
+  .pun {
+    color: #fefbec;
+  }
+
+  /* lisp open bracket */
+  .opn {
+    color: #fefbec;
+  }
+
+  /* lisp close bracket */
+  .clo {
+    color: #fefbec;
+  }
+
+  /* a markup tag name */
+  .tag {
+    color: #d73737;
+  }
+
+  /* a markup attribute name */
+  .atn {
+    color: #b65611;
+  }
+
+  /* a markup attribute value */
+  .atv {
+    color: #1fad83;
+  }
+
+  /* a declaration */
+  .dec {
+    color: #b65611;
+  }
+
+  /* a variable name */
+  .var {
+    color: #d73737;
+  }
+
+  /* a function name */
+  .fun {
+    color: #6684e1;
+  }
+}
+/* Use higher contrast and text-weight for printable form. */
+@media print, projection {
+  .str {
+    color: #006600;
+  }
+
+  .kwd {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .com {
+    color: #600;
+    font-style: italic;
+  }
+
+  .typ {
+    color: #404;
+    font-weight: bold;
+  }
+
+  .lit {
+    color: #004444;
+  }
+
+  .pun, .opn, .clo {
+    color: #444400;
+  }
+
+  .tag {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .atn {
+    color: #440044;
+  }
+
+  .atv {
+    color: #006600;
+  }
+}
+/* Style */
+pre.prettyprint {
+  background: #20201d;
+  color: #6e6b5e;
+  font-family: Consolas, Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  border: 1px solid #20201d;
+  padding: 10px;
+  border-radius: 3px;
+}
+
+/* Specify class=linenums on a pre to get line numbering */
+ol.linenums {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* IE indents via margin-left */
+li.L0,
+li.L1,
+li.L2,
+li.L3,
+li.L4,
+li.L5,
+li.L6,
+li.L7,
+li.L8,
+li.L9 {
+  /* */
+}
+
+/* Alternate shading for lines */
+li.L1,
+li.L3,
+li.L5,
+li.L7,
+li.L9 {
+  /* */
+}

--- a/styles/atelier-dune-light.css
+++ b/styles/atelier-dune-light.css
@@ -1,0 +1,160 @@
+/* Atelier Dune Light by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/dune) */
+
+/* plain text */
+.pln {
+  color: #20201d;
+}
+
+@media screen {
+  /* string content */
+  .str {
+    color: #60ac39;
+  }
+
+  /* a keyword */
+  .kwd {
+    color: #b854d4;
+  }
+
+  /* a comment */
+  .com {
+    color: #999580;
+  }
+
+  /* a type name */
+  .typ {
+    color: #6684e1;
+  }
+
+  /* a literal value */
+  .lit {
+    color: #b65611;
+  }
+
+  /* punctuation */
+  .pun {
+    color: #20201d;
+  }
+
+  /* lisp open bracket */
+  .opn {
+    color: #20201d;
+  }
+
+  /* lisp close bracket */
+  .clo {
+    color: #20201d;
+  }
+
+  /* a markup tag name */
+  .tag {
+    color: #d73737;
+  }
+
+  /* a markup attribute name */
+  .atn {
+    color: #b65611;
+  }
+
+  /* a markup attribute value */
+  .atv {
+    color: #1fad83;
+  }
+
+  /* a declaration */
+  .dec {
+    color: #b65611;
+  }
+
+  /* a variable name */
+  .var {
+    color: #d73737;
+  }
+
+  /* a function name */
+  .fun {
+    color: #6684e1;
+  }
+}
+/* Use higher contrast and text-weight for printable form. */
+@media print, projection {
+  .str {
+    color: #006600;
+  }
+
+  .kwd {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .com {
+    color: #600;
+    font-style: italic;
+  }
+
+  .typ {
+    color: #404;
+    font-weight: bold;
+  }
+
+  .lit {
+    color: #004444;
+  }
+
+  .pun, .opn, .clo {
+    color: #444400;
+  }
+
+  .tag {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .atn {
+    color: #440044;
+  }
+
+  .atv {
+    color: #006600;
+  }
+}
+/* Style */
+pre.prettyprint {
+  background: #fefbec;
+  color: #a6a28c;
+  font-family: Consolas, Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  border: 1px solid #e8e4cf;
+  padding: 10px;
+  border-radius: 3px;
+}
+
+/* Specify class=linenums on a pre to get line numbering */
+ol.linenums {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* IE indents via margin-left */
+li.L0,
+li.L1,
+li.L2,
+li.L3,
+li.L4,
+li.L5,
+li.L6,
+li.L7,
+li.L8,
+li.L9 {
+  /* */
+}
+
+/* Alternate shading for lines */
+li.L1,
+li.L3,
+li.L5,
+li.L7,
+li.L9 {
+  /* */
+}

--- a/styles/atelier-estuary-dark.css
+++ b/styles/atelier-estuary-dark.css
@@ -1,0 +1,160 @@
+/* Atelier Estuary Dark by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/estuary) */
+
+/* plain text */
+.pln {
+  color: #f4f3ec;
+}
+
+@media screen {
+  /* string content */
+  .str {
+    color: #7d9726;
+  }
+
+  /* a keyword */
+  .kwd {
+    color: #5f9182;
+  }
+
+  /* a comment */
+  .com {
+    color: #6c6b5a;
+  }
+
+  /* a type name */
+  .typ {
+    color: #36a166;
+  }
+
+  /* a literal value */
+  .lit {
+    color: #ae7313;
+  }
+
+  /* punctuation */
+  .pun {
+    color: #f4f3ec;
+  }
+
+  /* lisp open bracket */
+  .opn {
+    color: #f4f3ec;
+  }
+
+  /* lisp close bracket */
+  .clo {
+    color: #f4f3ec;
+  }
+
+  /* a markup tag name */
+  .tag {
+    color: #ba6236;
+  }
+
+  /* a markup attribute name */
+  .atn {
+    color: #ae7313;
+  }
+
+  /* a markup attribute value */
+  .atv {
+    color: #5b9d48;
+  }
+
+  /* a declaration */
+  .dec {
+    color: #ae7313;
+  }
+
+  /* a variable name */
+  .var {
+    color: #ba6236;
+  }
+
+  /* a function name */
+  .fun {
+    color: #36a166;
+  }
+}
+/* Use higher contrast and text-weight for printable form. */
+@media print, projection {
+  .str {
+    color: #006600;
+  }
+
+  .kwd {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .com {
+    color: #600;
+    font-style: italic;
+  }
+
+  .typ {
+    color: #404;
+    font-weight: bold;
+  }
+
+  .lit {
+    color: #004444;
+  }
+
+  .pun, .opn, .clo {
+    color: #444400;
+  }
+
+  .tag {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .atn {
+    color: #440044;
+  }
+
+  .atv {
+    color: #006600;
+  }
+}
+/* Style */
+pre.prettyprint {
+  background: #22221b;
+  color: #5f5e4e;
+  font-family: Consolas, Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  border: 1px solid #22221b;
+  padding: 10px;
+  border-radius: 3px;
+}
+
+/* Specify class=linenums on a pre to get line numbering */
+ol.linenums {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* IE indents via margin-left */
+li.L0,
+li.L1,
+li.L2,
+li.L3,
+li.L4,
+li.L5,
+li.L6,
+li.L7,
+li.L8,
+li.L9 {
+  /* */
+}
+
+/* Alternate shading for lines */
+li.L1,
+li.L3,
+li.L5,
+li.L7,
+li.L9 {
+  /* */
+}

--- a/styles/atelier-estuary-light.css
+++ b/styles/atelier-estuary-light.css
@@ -1,0 +1,160 @@
+/* Atelier Estuary Light by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/estuary) */
+
+/* plain text */
+.pln {
+  color: #22221b;
+}
+
+@media screen {
+  /* string content */
+  .str {
+    color: #7d9726;
+  }
+
+  /* a keyword */
+  .kwd {
+    color: #5f9182;
+  }
+
+  /* a comment */
+  .com {
+    color: #878573;
+  }
+
+  /* a type name */
+  .typ {
+    color: #36a166;
+  }
+
+  /* a literal value */
+  .lit {
+    color: #ae7313;
+  }
+
+  /* punctuation */
+  .pun {
+    color: #22221b;
+  }
+
+  /* lisp open bracket */
+  .opn {
+    color: #22221b;
+  }
+
+  /* lisp close bracket */
+  .clo {
+    color: #22221b;
+  }
+
+  /* a markup tag name */
+  .tag {
+    color: #ba6236;
+  }
+
+  /* a markup attribute name */
+  .atn {
+    color: #ae7313;
+  }
+
+  /* a markup attribute value */
+  .atv {
+    color: #5b9d48;
+  }
+
+  /* a declaration */
+  .dec {
+    color: #ae7313;
+  }
+
+  /* a variable name */
+  .var {
+    color: #ba6236;
+  }
+
+  /* a function name */
+  .fun {
+    color: #36a166;
+  }
+}
+/* Use higher contrast and text-weight for printable form. */
+@media print, projection {
+  .str {
+    color: #006600;
+  }
+
+  .kwd {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .com {
+    color: #600;
+    font-style: italic;
+  }
+
+  .typ {
+    color: #404;
+    font-weight: bold;
+  }
+
+  .lit {
+    color: #004444;
+  }
+
+  .pun, .opn, .clo {
+    color: #444400;
+  }
+
+  .tag {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .atn {
+    color: #440044;
+  }
+
+  .atv {
+    color: #006600;
+  }
+}
+/* Style */
+pre.prettyprint {
+  background: #f4f3ec;
+  color: #929181;
+  font-family: Consolas, Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  border: 1px solid #e7e6df;
+  padding: 10px;
+  border-radius: 3px;
+}
+
+/* Specify class=linenums on a pre to get line numbering */
+ol.linenums {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* IE indents via margin-left */
+li.L0,
+li.L1,
+li.L2,
+li.L3,
+li.L4,
+li.L5,
+li.L6,
+li.L7,
+li.L8,
+li.L9 {
+  /* */
+}
+
+/* Alternate shading for lines */
+li.L1,
+li.L3,
+li.L5,
+li.L7,
+li.L9 {
+  /* */
+}

--- a/styles/atelier-forest-dark.css
+++ b/styles/atelier-forest-dark.css
@@ -1,0 +1,160 @@
+/* Atelier Forest Dark by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/forest) */
+
+/* plain text */
+.pln {
+  color: #f1efee;
+}
+
+@media screen {
+  /* string content */
+  .str {
+    color: #7b9726;
+  }
+
+  /* a keyword */
+  .kwd {
+    color: #6666ea;
+  }
+
+  /* a comment */
+  .com {
+    color: #766e6b;
+  }
+
+  /* a type name */
+  .typ {
+    color: #407ee7;
+  }
+
+  /* a literal value */
+  .lit {
+    color: #df5320;
+  }
+
+  /* punctuation */
+  .pun {
+    color: #f1efee;
+  }
+
+  /* lisp open bracket */
+  .opn {
+    color: #f1efee;
+  }
+
+  /* lisp close bracket */
+  .clo {
+    color: #f1efee;
+  }
+
+  /* a markup tag name */
+  .tag {
+    color: #f22c40;
+  }
+
+  /* a markup attribute name */
+  .atn {
+    color: #df5320;
+  }
+
+  /* a markup attribute value */
+  .atv {
+    color: #3d97b8;
+  }
+
+  /* a declaration */
+  .dec {
+    color: #df5320;
+  }
+
+  /* a variable name */
+  .var {
+    color: #f22c40;
+  }
+
+  /* a function name */
+  .fun {
+    color: #407ee7;
+  }
+}
+/* Use higher contrast and text-weight for printable form. */
+@media print, projection {
+  .str {
+    color: #006600;
+  }
+
+  .kwd {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .com {
+    color: #600;
+    font-style: italic;
+  }
+
+  .typ {
+    color: #404;
+    font-weight: bold;
+  }
+
+  .lit {
+    color: #004444;
+  }
+
+  .pun, .opn, .clo {
+    color: #444400;
+  }
+
+  .tag {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .atn {
+    color: #440044;
+  }
+
+  .atv {
+    color: #006600;
+  }
+}
+/* Style */
+pre.prettyprint {
+  background: #1b1918;
+  color: #68615e;
+  font-family: Consolas, Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  border: 1px solid #1b1918;
+  padding: 10px;
+  border-radius: 3px;
+}
+
+/* Specify class=linenums on a pre to get line numbering */
+ol.linenums {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* IE indents via margin-left */
+li.L0,
+li.L1,
+li.L2,
+li.L3,
+li.L4,
+li.L5,
+li.L6,
+li.L7,
+li.L8,
+li.L9 {
+  /* */
+}
+
+/* Alternate shading for lines */
+li.L1,
+li.L3,
+li.L5,
+li.L7,
+li.L9 {
+  /* */
+}

--- a/styles/atelier-forest-light.css
+++ b/styles/atelier-forest-light.css
@@ -1,0 +1,160 @@
+/* Atelier Forest Light by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/forest) */
+
+/* plain text */
+.pln {
+  color: #1b1918;
+}
+
+@media screen {
+  /* string content */
+  .str {
+    color: #7b9726;
+  }
+
+  /* a keyword */
+  .kwd {
+    color: #6666ea;
+  }
+
+  /* a comment */
+  .com {
+    color: #9c9491;
+  }
+
+  /* a type name */
+  .typ {
+    color: #407ee7;
+  }
+
+  /* a literal value */
+  .lit {
+    color: #df5320;
+  }
+
+  /* punctuation */
+  .pun {
+    color: #1b1918;
+  }
+
+  /* lisp open bracket */
+  .opn {
+    color: #1b1918;
+  }
+
+  /* lisp close bracket */
+  .clo {
+    color: #1b1918;
+  }
+
+  /* a markup tag name */
+  .tag {
+    color: #f22c40;
+  }
+
+  /* a markup attribute name */
+  .atn {
+    color: #df5320;
+  }
+
+  /* a markup attribute value */
+  .atv {
+    color: #3d97b8;
+  }
+
+  /* a declaration */
+  .dec {
+    color: #df5320;
+  }
+
+  /* a variable name */
+  .var {
+    color: #f22c40;
+  }
+
+  /* a function name */
+  .fun {
+    color: #407ee7;
+  }
+}
+/* Use higher contrast and text-weight for printable form. */
+@media print, projection {
+  .str {
+    color: #006600;
+  }
+
+  .kwd {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .com {
+    color: #600;
+    font-style: italic;
+  }
+
+  .typ {
+    color: #404;
+    font-weight: bold;
+  }
+
+  .lit {
+    color: #004444;
+  }
+
+  .pun, .opn, .clo {
+    color: #444400;
+  }
+
+  .tag {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .atn {
+    color: #440044;
+  }
+
+  .atv {
+    color: #006600;
+  }
+}
+/* Style */
+pre.prettyprint {
+  background: #f1efee;
+  color: #a8a19f;
+  font-family: Consolas, Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  border: 1px solid #e6e2e0;
+  padding: 10px;
+  border-radius: 3px;
+}
+
+/* Specify class=linenums on a pre to get line numbering */
+ol.linenums {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* IE indents via margin-left */
+li.L0,
+li.L1,
+li.L2,
+li.L3,
+li.L4,
+li.L5,
+li.L6,
+li.L7,
+li.L8,
+li.L9 {
+  /* */
+}
+
+/* Alternate shading for lines */
+li.L1,
+li.L3,
+li.L5,
+li.L7,
+li.L9 {
+  /* */
+}

--- a/styles/atelier-heath-dark.css
+++ b/styles/atelier-heath-dark.css
@@ -1,0 +1,160 @@
+/* Atelier Heath Dark by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/heath) */
+
+/* plain text */
+.pln {
+  color: #f7f3f7;
+}
+
+@media screen {
+  /* string content */
+  .str {
+    color: #918b3b;
+  }
+
+  /* a keyword */
+  .kwd {
+    color: #7b59c0;
+  }
+
+  /* a comment */
+  .com {
+    color: #776977;
+  }
+
+  /* a type name */
+  .typ {
+    color: #516aec;
+  }
+
+  /* a literal value */
+  .lit {
+    color: #a65926;
+  }
+
+  /* punctuation */
+  .pun {
+    color: #f7f3f7;
+  }
+
+  /* lisp open bracket */
+  .opn {
+    color: #f7f3f7;
+  }
+
+  /* lisp close bracket */
+  .clo {
+    color: #f7f3f7;
+  }
+
+  /* a markup tag name */
+  .tag {
+    color: #ca402b;
+  }
+
+  /* a markup attribute name */
+  .atn {
+    color: #a65926;
+  }
+
+  /* a markup attribute value */
+  .atv {
+    color: #159393;
+  }
+
+  /* a declaration */
+  .dec {
+    color: #a65926;
+  }
+
+  /* a variable name */
+  .var {
+    color: #ca402b;
+  }
+
+  /* a function name */
+  .fun {
+    color: #516aec;
+  }
+}
+/* Use higher contrast and text-weight for printable form. */
+@media print, projection {
+  .str {
+    color: #006600;
+  }
+
+  .kwd {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .com {
+    color: #600;
+    font-style: italic;
+  }
+
+  .typ {
+    color: #404;
+    font-weight: bold;
+  }
+
+  .lit {
+    color: #004444;
+  }
+
+  .pun, .opn, .clo {
+    color: #444400;
+  }
+
+  .tag {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .atn {
+    color: #440044;
+  }
+
+  .atv {
+    color: #006600;
+  }
+}
+/* Style */
+pre.prettyprint {
+  background: #1b181b;
+  color: #695d69;
+  font-family: Consolas, Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  border: 1px solid #1b181b;
+  padding: 10px;
+  border-radius: 3px;
+}
+
+/* Specify class=linenums on a pre to get line numbering */
+ol.linenums {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* IE indents via margin-left */
+li.L0,
+li.L1,
+li.L2,
+li.L3,
+li.L4,
+li.L5,
+li.L6,
+li.L7,
+li.L8,
+li.L9 {
+  /* */
+}
+
+/* Alternate shading for lines */
+li.L1,
+li.L3,
+li.L5,
+li.L7,
+li.L9 {
+  /* */
+}

--- a/styles/atelier-heath-light.css
+++ b/styles/atelier-heath-light.css
@@ -1,0 +1,160 @@
+/* Atelier Heath Light by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/heath) */
+
+/* plain text */
+.pln {
+  color: #1b181b;
+}
+
+@media screen {
+  /* string content */
+  .str {
+    color: #918b3b;
+  }
+
+  /* a keyword */
+  .kwd {
+    color: #7b59c0;
+  }
+
+  /* a comment */
+  .com {
+    color: #9e8f9e;
+  }
+
+  /* a type name */
+  .typ {
+    color: #516aec;
+  }
+
+  /* a literal value */
+  .lit {
+    color: #a65926;
+  }
+
+  /* punctuation */
+  .pun {
+    color: #1b181b;
+  }
+
+  /* lisp open bracket */
+  .opn {
+    color: #1b181b;
+  }
+
+  /* lisp close bracket */
+  .clo {
+    color: #1b181b;
+  }
+
+  /* a markup tag name */
+  .tag {
+    color: #ca402b;
+  }
+
+  /* a markup attribute name */
+  .atn {
+    color: #a65926;
+  }
+
+  /* a markup attribute value */
+  .atv {
+    color: #159393;
+  }
+
+  /* a declaration */
+  .dec {
+    color: #a65926;
+  }
+
+  /* a variable name */
+  .var {
+    color: #ca402b;
+  }
+
+  /* a function name */
+  .fun {
+    color: #516aec;
+  }
+}
+/* Use higher contrast and text-weight for printable form. */
+@media print, projection {
+  .str {
+    color: #006600;
+  }
+
+  .kwd {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .com {
+    color: #600;
+    font-style: italic;
+  }
+
+  .typ {
+    color: #404;
+    font-weight: bold;
+  }
+
+  .lit {
+    color: #004444;
+  }
+
+  .pun, .opn, .clo {
+    color: #444400;
+  }
+
+  .tag {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .atn {
+    color: #440044;
+  }
+
+  .atv {
+    color: #006600;
+  }
+}
+/* Style */
+pre.prettyprint {
+  background: #f7f3f7;
+  color: #ab9bab;
+  font-family: Consolas, Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  border: 1px solid #d8cad8;
+  padding: 10px;
+  border-radius: 3px;
+}
+
+/* Specify class=linenums on a pre to get line numbering */
+ol.linenums {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* IE indents via margin-left */
+li.L0,
+li.L1,
+li.L2,
+li.L3,
+li.L4,
+li.L5,
+li.L6,
+li.L7,
+li.L8,
+li.L9 {
+  /* */
+}
+
+/* Alternate shading for lines */
+li.L1,
+li.L3,
+li.L5,
+li.L7,
+li.L9 {
+  /* */
+}

--- a/styles/atelier-lakeside-dark.css
+++ b/styles/atelier-lakeside-dark.css
@@ -1,0 +1,160 @@
+/* Atelier Lakeside Dark by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/lakeside/) */
+
+/* plain text */
+.pln {
+  color: #ebf8ff;
+}
+
+@media screen {
+  /* string content */
+  .str {
+    color: #568c3b;
+  }
+
+  /* a keyword */
+  .kwd {
+    color: #6b6bb8;
+  }
+
+  /* a comment */
+  .com {
+    color: #5a7b8c;
+  }
+
+  /* a type name */
+  .typ {
+    color: #257fad;
+  }
+
+  /* a literal value */
+  .lit {
+    color: #935c25;
+  }
+
+  /* punctuation */
+  .pun {
+    color: #ebf8ff;
+  }
+
+  /* lisp open bracket */
+  .opn {
+    color: #ebf8ff;
+  }
+
+  /* lisp close bracket */
+  .clo {
+    color: #ebf8ff;
+  }
+
+  /* a markup tag name */
+  .tag {
+    color: #d22d72;
+  }
+
+  /* a markup attribute name */
+  .atn {
+    color: #935c25;
+  }
+
+  /* a markup attribute value */
+  .atv {
+    color: #2d8f6f;
+  }
+
+  /* a declaration */
+  .dec {
+    color: #935c25;
+  }
+
+  /* a variable name */
+  .var {
+    color: #d22d72;
+  }
+
+  /* a function name */
+  .fun {
+    color: #257fad;
+  }
+}
+/* Use higher contrast and text-weight for printable form. */
+@media print, projection {
+  .str {
+    color: #006600;
+  }
+
+  .kwd {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .com {
+    color: #600;
+    font-style: italic;
+  }
+
+  .typ {
+    color: #404;
+    font-weight: bold;
+  }
+
+  .lit {
+    color: #004444;
+  }
+
+  .pun, .opn, .clo {
+    color: #444400;
+  }
+
+  .tag {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .atn {
+    color: #440044;
+  }
+
+  .atv {
+    color: #006600;
+  }
+}
+/* Style */
+pre.prettyprint {
+  background: #161b1d;
+  color: #516d7b;
+  font-family: Consolas, Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  border: 1px solid #161b1d;
+  padding: 10px;
+  border-radius: 3px;
+}
+
+/* Specify class=linenums on a pre to get line numbering */
+ol.linenums {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* IE indents via margin-left */
+li.L0,
+li.L1,
+li.L2,
+li.L3,
+li.L4,
+li.L5,
+li.L6,
+li.L7,
+li.L8,
+li.L9 {
+  /* */
+}
+
+/* Alternate shading for lines */
+li.L1,
+li.L3,
+li.L5,
+li.L7,
+li.L9 {
+  /* */
+}

--- a/styles/atelier-lakeside-light.css
+++ b/styles/atelier-lakeside-light.css
@@ -1,0 +1,160 @@
+/* Atelier Lakeside Light by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/lakeside/) */
+
+/* plain text */
+.pln {
+  color: #161b1d;
+}
+
+@media screen {
+  /* string content */
+  .str {
+    color: #568c3b;
+  }
+
+  /* a keyword */
+  .kwd {
+    color: #6b6bb8;
+  }
+
+  /* a comment */
+  .com {
+    color: #7195a8;
+  }
+
+  /* a type name */
+  .typ {
+    color: #257fad;
+  }
+
+  /* a literal value */
+  .lit {
+    color: #935c25;
+  }
+
+  /* punctuation */
+  .pun {
+    color: #161b1d;
+  }
+
+  /* lisp open bracket */
+  .opn {
+    color: #161b1d;
+  }
+
+  /* lisp close bracket */
+  .clo {
+    color: #161b1d;
+  }
+
+  /* a markup tag name */
+  .tag {
+    color: #d22d72;
+  }
+
+  /* a markup attribute name */
+  .atn {
+    color: #935c25;
+  }
+
+  /* a markup attribute value */
+  .atv {
+    color: #2d8f6f;
+  }
+
+  /* a declaration */
+  .dec {
+    color: #935c25;
+  }
+
+  /* a variable name */
+  .var {
+    color: #d22d72;
+  }
+
+  /* a function name */
+  .fun {
+    color: #257fad;
+  }
+}
+/* Use higher contrast and text-weight for printable form. */
+@media print, projection {
+  .str {
+    color: #006600;
+  }
+
+  .kwd {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .com {
+    color: #600;
+    font-style: italic;
+  }
+
+  .typ {
+    color: #404;
+    font-weight: bold;
+  }
+
+  .lit {
+    color: #004444;
+  }
+
+  .pun, .opn, .clo {
+    color: #444400;
+  }
+
+  .tag {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .atn {
+    color: #440044;
+  }
+
+  .atv {
+    color: #006600;
+  }
+}
+/* Style */
+pre.prettyprint {
+  background: #ebf8ff;
+  color: #7ea2b4;
+  font-family: Consolas, Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  border: 1px solid #c1e4f6;
+  padding: 10px;
+  border-radius: 3px;
+}
+
+/* Specify class=linenums on a pre to get line numbering */
+ol.linenums {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* IE indents via margin-left */
+li.L0,
+li.L1,
+li.L2,
+li.L3,
+li.L4,
+li.L5,
+li.L6,
+li.L7,
+li.L8,
+li.L9 {
+  /* */
+}
+
+/* Alternate shading for lines */
+li.L1,
+li.L3,
+li.L5,
+li.L7,
+li.L9 {
+  /* */
+}

--- a/styles/atelier-plateau-dark.css
+++ b/styles/atelier-plateau-dark.css
@@ -1,0 +1,160 @@
+/* Atelier Plateau Dark by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/plateau) */
+
+/* plain text */
+.pln {
+  color: #f4ecec;
+}
+
+@media screen {
+  /* string content */
+  .str {
+    color: #4b8b8b;
+  }
+
+  /* a keyword */
+  .kwd {
+    color: #8464c4;
+  }
+
+  /* a comment */
+  .com {
+    color: #655d5d;
+  }
+
+  /* a type name */
+  .typ {
+    color: #7272ca;
+  }
+
+  /* a literal value */
+  .lit {
+    color: #b45a3c;
+  }
+
+  /* punctuation */
+  .pun {
+    color: #f4ecec;
+  }
+
+  /* lisp open bracket */
+  .opn {
+    color: #f4ecec;
+  }
+
+  /* lisp close bracket */
+  .clo {
+    color: #f4ecec;
+  }
+
+  /* a markup tag name */
+  .tag {
+    color: #ca4949;
+  }
+
+  /* a markup attribute name */
+  .atn {
+    color: #b45a3c;
+  }
+
+  /* a markup attribute value */
+  .atv {
+    color: #5485b6;
+  }
+
+  /* a declaration */
+  .dec {
+    color: #b45a3c;
+  }
+
+  /* a variable name */
+  .var {
+    color: #ca4949;
+  }
+
+  /* a function name */
+  .fun {
+    color: #7272ca;
+  }
+}
+/* Use higher contrast and text-weight for printable form. */
+@media print, projection {
+  .str {
+    color: #006600;
+  }
+
+  .kwd {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .com {
+    color: #600;
+    font-style: italic;
+  }
+
+  .typ {
+    color: #404;
+    font-weight: bold;
+  }
+
+  .lit {
+    color: #004444;
+  }
+
+  .pun, .opn, .clo {
+    color: #444400;
+  }
+
+  .tag {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .atn {
+    color: #440044;
+  }
+
+  .atv {
+    color: #006600;
+  }
+}
+/* Style */
+pre.prettyprint {
+  background: #1b1818;
+  color: #585050;
+  font-family: Consolas, Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  border: 1px solid #1b1818;
+  padding: 10px;
+  border-radius: 3px;
+}
+
+/* Specify class=linenums on a pre to get line numbering */
+ol.linenums {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* IE indents via margin-left */
+li.L0,
+li.L1,
+li.L2,
+li.L3,
+li.L4,
+li.L5,
+li.L6,
+li.L7,
+li.L8,
+li.L9 {
+  /* */
+}
+
+/* Alternate shading for lines */
+li.L1,
+li.L3,
+li.L5,
+li.L7,
+li.L9 {
+  /* */
+}

--- a/styles/atelier-plateau-light.css
+++ b/styles/atelier-plateau-light.css
@@ -1,0 +1,160 @@
+/* Atelier Plateau Light by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/plateau) */
+
+/* plain text */
+.pln {
+  color: #1b1818;
+}
+
+@media screen {
+  /* string content */
+  .str {
+    color: #4b8b8b;
+  }
+
+  /* a keyword */
+  .kwd {
+    color: #8464c4;
+  }
+
+  /* a comment */
+  .com {
+    color: #7e7777;
+  }
+
+  /* a type name */
+  .typ {
+    color: #7272ca;
+  }
+
+  /* a literal value */
+  .lit {
+    color: #b45a3c;
+  }
+
+  /* punctuation */
+  .pun {
+    color: #1b1818;
+  }
+
+  /* lisp open bracket */
+  .opn {
+    color: #1b1818;
+  }
+
+  /* lisp close bracket */
+  .clo {
+    color: #1b1818;
+  }
+
+  /* a markup tag name */
+  .tag {
+    color: #ca4949;
+  }
+
+  /* a markup attribute name */
+  .atn {
+    color: #b45a3c;
+  }
+
+  /* a markup attribute value */
+  .atv {
+    color: #5485b6;
+  }
+
+  /* a declaration */
+  .dec {
+    color: #b45a3c;
+  }
+
+  /* a variable name */
+  .var {
+    color: #ca4949;
+  }
+
+  /* a function name */
+  .fun {
+    color: #7272ca;
+  }
+}
+/* Use higher contrast and text-weight for printable form. */
+@media print, projection {
+  .str {
+    color: #006600;
+  }
+
+  .kwd {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .com {
+    color: #600;
+    font-style: italic;
+  }
+
+  .typ {
+    color: #404;
+    font-weight: bold;
+  }
+
+  .lit {
+    color: #004444;
+  }
+
+  .pun, .opn, .clo {
+    color: #444400;
+  }
+
+  .tag {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .atn {
+    color: #440044;
+  }
+
+  .atv {
+    color: #006600;
+  }
+}
+/* Style */
+pre.prettyprint {
+  background: #f4ecec;
+  color: #8a8585;
+  font-family: Consolas, Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  border: 1px solid #e7dfdf;
+  padding: 10px;
+  border-radius: 3px;
+}
+
+/* Specify class=linenums on a pre to get line numbering */
+ol.linenums {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* IE indents via margin-left */
+li.L0,
+li.L1,
+li.L2,
+li.L3,
+li.L4,
+li.L5,
+li.L6,
+li.L7,
+li.L8,
+li.L9 {
+  /* */
+}
+
+/* Alternate shading for lines */
+li.L1,
+li.L3,
+li.L5,
+li.L7,
+li.L9 {
+  /* */
+}

--- a/styles/atelier-savanna-dark.css
+++ b/styles/atelier-savanna-dark.css
@@ -1,0 +1,160 @@
+/* Atelier Savanna Dark by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/savanna) */
+
+/* plain text */
+.pln {
+  color: #ecf4ee;
+}
+
+@media screen {
+  /* string content */
+  .str {
+    color: #489963;
+  }
+
+  /* a keyword */
+  .kwd {
+    color: #55859b;
+  }
+
+  /* a comment */
+  .com {
+    color: #5f6d64;
+  }
+
+  /* a type name */
+  .typ {
+    color: #478c90;
+  }
+
+  /* a literal value */
+  .lit {
+    color: #9f713c;
+  }
+
+  /* punctuation */
+  .pun {
+    color: #ecf4ee;
+  }
+
+  /* lisp open bracket */
+  .opn {
+    color: #ecf4ee;
+  }
+
+  /* lisp close bracket */
+  .clo {
+    color: #ecf4ee;
+  }
+
+  /* a markup tag name */
+  .tag {
+    color: #b16139;
+  }
+
+  /* a markup attribute name */
+  .atn {
+    color: #9f713c;
+  }
+
+  /* a markup attribute value */
+  .atv {
+    color: #1c9aa0;
+  }
+
+  /* a declaration */
+  .dec {
+    color: #9f713c;
+  }
+
+  /* a variable name */
+  .var {
+    color: #b16139;
+  }
+
+  /* a function name */
+  .fun {
+    color: #478c90;
+  }
+}
+/* Use higher contrast and text-weight for printable form. */
+@media print, projection {
+  .str {
+    color: #006600;
+  }
+
+  .kwd {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .com {
+    color: #600;
+    font-style: italic;
+  }
+
+  .typ {
+    color: #404;
+    font-weight: bold;
+  }
+
+  .lit {
+    color: #004444;
+  }
+
+  .pun, .opn, .clo {
+    color: #444400;
+  }
+
+  .tag {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .atn {
+    color: #440044;
+  }
+
+  .atv {
+    color: #006600;
+  }
+}
+/* Style */
+pre.prettyprint {
+  background: #171c19;
+  color: #526057;
+  font-family: Consolas, Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  border: 1px solid #171c19;
+  padding: 10px;
+  border-radius: 3px;
+}
+
+/* Specify class=linenums on a pre to get line numbering */
+ol.linenums {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* IE indents via margin-left */
+li.L0,
+li.L1,
+li.L2,
+li.L3,
+li.L4,
+li.L5,
+li.L6,
+li.L7,
+li.L8,
+li.L9 {
+  /* */
+}
+
+/* Alternate shading for lines */
+li.L1,
+li.L3,
+li.L5,
+li.L7,
+li.L9 {
+  /* */
+}

--- a/styles/atelier-savanna-light.css
+++ b/styles/atelier-savanna-light.css
@@ -1,0 +1,160 @@
+/* Atelier Savanna Light by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/savanna) */
+
+/* plain text */
+.pln {
+  color: #171c19;
+}
+
+@media screen {
+  /* string content */
+  .str {
+    color: #489963;
+  }
+
+  /* a keyword */
+  .kwd {
+    color: #55859b;
+  }
+
+  /* a comment */
+  .com {
+    color: #78877d;
+  }
+
+  /* a type name */
+  .typ {
+    color: #478c90;
+  }
+
+  /* a literal value */
+  .lit {
+    color: #9f713c;
+  }
+
+  /* punctuation */
+  .pun {
+    color: #171c19;
+  }
+
+  /* lisp open bracket */
+  .opn {
+    color: #171c19;
+  }
+
+  /* lisp close bracket */
+  .clo {
+    color: #171c19;
+  }
+
+  /* a markup tag name */
+  .tag {
+    color: #b16139;
+  }
+
+  /* a markup attribute name */
+  .atn {
+    color: #9f713c;
+  }
+
+  /* a markup attribute value */
+  .atv {
+    color: #1c9aa0;
+  }
+
+  /* a declaration */
+  .dec {
+    color: #9f713c;
+  }
+
+  /* a variable name */
+  .var {
+    color: #b16139;
+  }
+
+  /* a function name */
+  .fun {
+    color: #478c90;
+  }
+}
+/* Use higher contrast and text-weight for printable form. */
+@media print, projection {
+  .str {
+    color: #006600;
+  }
+
+  .kwd {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .com {
+    color: #600;
+    font-style: italic;
+  }
+
+  .typ {
+    color: #404;
+    font-weight: bold;
+  }
+
+  .lit {
+    color: #004444;
+  }
+
+  .pun, .opn, .clo {
+    color: #444400;
+  }
+
+  .tag {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .atn {
+    color: #440044;
+  }
+
+  .atv {
+    color: #006600;
+  }
+}
+/* Style */
+pre.prettyprint {
+  background: #ecf4ee;
+  color: #87928a;
+  font-family: Consolas, Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  border: 1px solid #dfe7e2;
+  padding: 10px;
+  border-radius: 3px;
+}
+
+/* Specify class=linenums on a pre to get line numbering */
+ol.linenums {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* IE indents via margin-left */
+li.L0,
+li.L1,
+li.L2,
+li.L3,
+li.L4,
+li.L5,
+li.L6,
+li.L7,
+li.L8,
+li.L9 {
+  /* */
+}
+
+/* Alternate shading for lines */
+li.L1,
+li.L3,
+li.L5,
+li.L7,
+li.L9 {
+  /* */
+}

--- a/styles/atelier-seaside-dark.css
+++ b/styles/atelier-seaside-dark.css
@@ -1,0 +1,160 @@
+/* Atelier Seaside Dark by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/seaside/) */
+
+/* plain text */
+.pln {
+  color: #f4fbf4;
+}
+
+@media screen {
+  /* string content */
+  .str {
+    color: #29a329;
+  }
+
+  /* a keyword */
+  .kwd {
+    color: #ad2bee;
+  }
+
+  /* a comment */
+  .com {
+    color: #687d68;
+  }
+
+  /* a type name */
+  .typ {
+    color: #3d62f5;
+  }
+
+  /* a literal value */
+  .lit {
+    color: #87711d;
+  }
+
+  /* punctuation */
+  .pun {
+    color: #f4fbf4;
+  }
+
+  /* lisp open bracket */
+  .opn {
+    color: #f4fbf4;
+  }
+
+  /* lisp close bracket */
+  .clo {
+    color: #f4fbf4;
+  }
+
+  /* a markup tag name */
+  .tag {
+    color: #e6193c;
+  }
+
+  /* a markup attribute name */
+  .atn {
+    color: #87711d;
+  }
+
+  /* a markup attribute value */
+  .atv {
+    color: #1999b3;
+  }
+
+  /* a declaration */
+  .dec {
+    color: #87711d;
+  }
+
+  /* a variable name */
+  .var {
+    color: #e6193c;
+  }
+
+  /* a function name */
+  .fun {
+    color: #3d62f5;
+  }
+}
+/* Use higher contrast and text-weight for printable form. */
+@media print, projection {
+  .str {
+    color: #006600;
+  }
+
+  .kwd {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .com {
+    color: #600;
+    font-style: italic;
+  }
+
+  .typ {
+    color: #404;
+    font-weight: bold;
+  }
+
+  .lit {
+    color: #004444;
+  }
+
+  .pun, .opn, .clo {
+    color: #444400;
+  }
+
+  .tag {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .atn {
+    color: #440044;
+  }
+
+  .atv {
+    color: #006600;
+  }
+}
+/* Style */
+pre.prettyprint {
+  background: #131513;
+  color: #5e6e5e;
+  font-family: Consolas, Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  border: 1px solid #131513;
+  padding: 10px;
+  border-radius: 3px;
+}
+
+/* Specify class=linenums on a pre to get line numbering */
+ol.linenums {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* IE indents via margin-left */
+li.L0,
+li.L1,
+li.L2,
+li.L3,
+li.L4,
+li.L5,
+li.L6,
+li.L7,
+li.L8,
+li.L9 {
+  /* */
+}
+
+/* Alternate shading for lines */
+li.L1,
+li.L3,
+li.L5,
+li.L7,
+li.L9 {
+  /* */
+}

--- a/styles/atelier-seaside-light.css
+++ b/styles/atelier-seaside-light.css
@@ -1,0 +1,160 @@
+/* Atelier Seaside Light by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/seaside/) */
+
+/* plain text */
+.pln {
+  color: #131513;
+}
+
+@media screen {
+  /* string content */
+  .str {
+    color: #29a329;
+  }
+
+  /* a keyword */
+  .kwd {
+    color: #ad2bee;
+  }
+
+  /* a comment */
+  .com {
+    color: #809980;
+  }
+
+  /* a type name */
+  .typ {
+    color: #3d62f5;
+  }
+
+  /* a literal value */
+  .lit {
+    color: #87711d;
+  }
+
+  /* punctuation */
+  .pun {
+    color: #131513;
+  }
+
+  /* lisp open bracket */
+  .opn {
+    color: #131513;
+  }
+
+  /* lisp close bracket */
+  .clo {
+    color: #131513;
+  }
+
+  /* a markup tag name */
+  .tag {
+    color: #e6193c;
+  }
+
+  /* a markup attribute name */
+  .atn {
+    color: #87711d;
+  }
+
+  /* a markup attribute value */
+  .atv {
+    color: #1999b3;
+  }
+
+  /* a declaration */
+  .dec {
+    color: #87711d;
+  }
+
+  /* a variable name */
+  .var {
+    color: #e6193c;
+  }
+
+  /* a function name */
+  .fun {
+    color: #3d62f5;
+  }
+}
+/* Use higher contrast and text-weight for printable form. */
+@media print, projection {
+  .str {
+    color: #006600;
+  }
+
+  .kwd {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .com {
+    color: #600;
+    font-style: italic;
+  }
+
+  .typ {
+    color: #404;
+    font-weight: bold;
+  }
+
+  .lit {
+    color: #004444;
+  }
+
+  .pun, .opn, .clo {
+    color: #444400;
+  }
+
+  .tag {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .atn {
+    color: #440044;
+  }
+
+  .atv {
+    color: #006600;
+  }
+}
+/* Style */
+pre.prettyprint {
+  background: #f4fbf4;
+  color: #8ca68c;
+  font-family: Consolas, Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  border: 1px solid #cfe8cf;
+  padding: 10px;
+  border-radius: 3px;
+}
+
+/* Specify class=linenums on a pre to get line numbering */
+ol.linenums {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* IE indents via margin-left */
+li.L0,
+li.L1,
+li.L2,
+li.L3,
+li.L4,
+li.L5,
+li.L6,
+li.L7,
+li.L8,
+li.L9 {
+  /* */
+}
+
+/* Alternate shading for lines */
+li.L1,
+li.L3,
+li.L5,
+li.L7,
+li.L9 {
+  /* */
+}

--- a/styles/atelier-sulphurpool-dark.css
+++ b/styles/atelier-sulphurpool-dark.css
@@ -1,0 +1,160 @@
+/* Atelier Sulphurpool Dark by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/sulphurpool) */
+
+/* plain text */
+.pln {
+  color: #f5f7ff;
+}
+
+@media screen {
+  /* string content */
+  .str {
+    color: #ac9739;
+  }
+
+  /* a keyword */
+  .kwd {
+    color: #6679cc;
+  }
+
+  /* a comment */
+  .com {
+    color: #6b7394;
+  }
+
+  /* a type name */
+  .typ {
+    color: #3d8fd1;
+  }
+
+  /* a literal value */
+  .lit {
+    color: #c76b29;
+  }
+
+  /* punctuation */
+  .pun {
+    color: #f5f7ff;
+  }
+
+  /* lisp open bracket */
+  .opn {
+    color: #f5f7ff;
+  }
+
+  /* lisp close bracket */
+  .clo {
+    color: #f5f7ff;
+  }
+
+  /* a markup tag name */
+  .tag {
+    color: #c94922;
+  }
+
+  /* a markup attribute name */
+  .atn {
+    color: #c76b29;
+  }
+
+  /* a markup attribute value */
+  .atv {
+    color: #22a2c9;
+  }
+
+  /* a declaration */
+  .dec {
+    color: #c76b29;
+  }
+
+  /* a variable name */
+  .var {
+    color: #c94922;
+  }
+
+  /* a function name */
+  .fun {
+    color: #3d8fd1;
+  }
+}
+/* Use higher contrast and text-weight for printable form. */
+@media print, projection {
+  .str {
+    color: #006600;
+  }
+
+  .kwd {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .com {
+    color: #600;
+    font-style: italic;
+  }
+
+  .typ {
+    color: #404;
+    font-weight: bold;
+  }
+
+  .lit {
+    color: #004444;
+  }
+
+  .pun, .opn, .clo {
+    color: #444400;
+  }
+
+  .tag {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .atn {
+    color: #440044;
+  }
+
+  .atv {
+    color: #006600;
+  }
+}
+/* Style */
+pre.prettyprint {
+  background: #202746;
+  color: #5e6687;
+  font-family: Consolas, Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  border: 1px solid #202746;
+  padding: 10px;
+  border-radius: 3px;
+}
+
+/* Specify class=linenums on a pre to get line numbering */
+ol.linenums {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* IE indents via margin-left */
+li.L0,
+li.L1,
+li.L2,
+li.L3,
+li.L4,
+li.L5,
+li.L6,
+li.L7,
+li.L8,
+li.L9 {
+  /* */
+}
+
+/* Alternate shading for lines */
+li.L1,
+li.L3,
+li.L5,
+li.L7,
+li.L9 {
+  /* */
+}

--- a/styles/atelier-sulphurpool-light.css
+++ b/styles/atelier-sulphurpool-light.css
@@ -1,0 +1,160 @@
+/* Atelier Sulphurpool Light by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/sulphurpool) */
+
+/* plain text */
+.pln {
+  color: #202746;
+}
+
+@media screen {
+  /* string content */
+  .str {
+    color: #ac9739;
+  }
+
+  /* a keyword */
+  .kwd {
+    color: #6679cc;
+  }
+
+  /* a comment */
+  .com {
+    color: #898ea4;
+  }
+
+  /* a type name */
+  .typ {
+    color: #3d8fd1;
+  }
+
+  /* a literal value */
+  .lit {
+    color: #c76b29;
+  }
+
+  /* punctuation */
+  .pun {
+    color: #202746;
+  }
+
+  /* lisp open bracket */
+  .opn {
+    color: #202746;
+  }
+
+  /* lisp close bracket */
+  .clo {
+    color: #202746;
+  }
+
+  /* a markup tag name */
+  .tag {
+    color: #c94922;
+  }
+
+  /* a markup attribute name */
+  .atn {
+    color: #c76b29;
+  }
+
+  /* a markup attribute value */
+  .atv {
+    color: #22a2c9;
+  }
+
+  /* a declaration */
+  .dec {
+    color: #c76b29;
+  }
+
+  /* a variable name */
+  .var {
+    color: #c94922;
+  }
+
+  /* a function name */
+  .fun {
+    color: #3d8fd1;
+  }
+}
+/* Use higher contrast and text-weight for printable form. */
+@media print, projection {
+  .str {
+    color: #006600;
+  }
+
+  .kwd {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .com {
+    color: #600;
+    font-style: italic;
+  }
+
+  .typ {
+    color: #404;
+    font-weight: bold;
+  }
+
+  .lit {
+    color: #004444;
+  }
+
+  .pun, .opn, .clo {
+    color: #444400;
+  }
+
+  .tag {
+    color: #006;
+    font-weight: bold;
+  }
+
+  .atn {
+    color: #440044;
+  }
+
+  .atv {
+    color: #006600;
+  }
+}
+/* Style */
+pre.prettyprint {
+  background: #f5f7ff;
+  color: #979db4;
+  font-family: Consolas, Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  border: 1px solid #dfe2f1;
+  padding: 10px;
+  border-radius: 3px;
+}
+
+/* Specify class=linenums on a pre to get line numbering */
+ol.linenums {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* IE indents via margin-left */
+li.L0,
+li.L1,
+li.L2,
+li.L3,
+li.L4,
+li.L5,
+li.L6,
+li.L7,
+li.L8,
+li.L9 {
+  /* */
+}
+
+/* Alternate shading for lines */
+li.L1,
+li.L3,
+li.L5,
+li.L7,
+li.L9 {
+  /* */
+}

--- a/styles/index.html
+++ b/styles/index.html
@@ -15,6 +15,26 @@ var allThemes = [
     authorHtml: '<a href="http://CodeTunnel.com/blog/post/71'
         + '/google-code-prettify-obsidian-theme">Alex Ford<\/a>' },
   { name: 'doxy', authorHtml: 'Robert Sperberg' },
+  { name: 'atelier-cave-dark', authorHtml: '<a href="http://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave">Bram de Haan</a>' },
+  { name: 'atelier-cave-light', authorHtml: '<a href="http://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave">Bram de Haan</a>' },
+  { name: 'atelier-dune-dark', authorHtml: '<a href="http://atelierbram.github.io/syntax-highlighting/atelier-schemes/dune">Bram de Haan</a>' },
+  { name: 'atelier-dune-light', authorHtml: '<a href="http://atelierbram.github.io/syntax-highlighting/atelier-schemes/dune">Bram de Haan</a>' },
+  { name: 'atelier-estuary-dark', authorHtml: '<a href="http://atelierbram.github.io/syntax-highlighting/atelier-schemes/estuary">Bram de Haan</a>' },
+  { name: 'atelier-estuary-light', authorHtml: '<a href="http://atelierbram.github.io/syntax-highlighting/atelier-schemes/estuary">Bram de Haan</a>' },
+  { name: 'atelier-forest-dark', authorHtml: '<a href="http://atelierbram.github.io/syntax-highlighting/atelier-schemes/forest">Bram de Haan</a>' },
+  { name: 'atelier-forest-light', authorHtml: '<a href="http://atelierbram.github.io/syntax-highlighting/atelier-schemes/forest">Bram de Haan</a>' },
+  { name: 'atelier-heath-dark', authorHtml: '<a href="http://atelierbram.github.io/syntax-highlighting/atelier-schemes/heath">Bram de Haan</a>' },
+  { name: 'atelier-heath-light', authorHtml: '<a href="http://atelierbram.github.io/syntax-highlighting/atelier-schemes/heath">Bram de Haan</a>' },
+  { name: 'atelier-lakeside-dark', authorHtml: '<a href="http://atelierbram.github.io/syntax-highlighting/atelier-schemes/lakeside">Bram de Haan</a>' },
+  { name: 'atelier-lakeside-light', authorHtml: '<a href="http://atelierbram.github.io/syntax-highlighting/atelier-schemes/lakeside">Bram de Haan</a>' },
+  { name: 'atelier-plateau-dark', authorHtml: '<a href="http://atelierbram.github.io/syntax-highlighting/atelier-schemes/plateau">Bram de Haan</a>' },
+  { name: 'atelier-plateau-light', authorHtml: '<a href="http://atelierbram.github.io/syntax-highlighting/atelier-schemes/plateau">Bram de Haan</a>' },
+  { name: 'atelier-savanna-dark', authorHtml: '<a href="http://atelierbram.github.io/syntax-highlighting/atelier-schemes/savanna">Bram de Haan</a>' },
+  { name: 'atelier-savanna-light', authorHtml: '<a href="http://atelierbram.github.io/syntax-highlighting/atelier-schemes/savanna">Bram de Haan</a>' },
+  { name: 'atelier-seaside-dark', authorHtml: '<a href="http://atelierbram.github.io/syntax-highlighting/atelier-schemes/seaside">Bram de Haan</a>' },
+  { name: 'atelier-seaside-light', authorHtml: '<a href="http://atelierbram.github.io/syntax-highlighting/atelier-schemes/seaside">Bram de Haan</a>' },
+  { name: 'atelier-sulphurpool-dark', authorHtml: '<a href="http://atelierbram.github.io/syntax-highlighting/atelier-schemes/sulphurpool">Bram de Haan</a>' },
+  { name: 'atelier-sulphurpool-light', authorHtml: '<a href="http://atelierbram.github.io/syntax-highlighting/atelier-schemes/sulphurpool">Bram de Haan</a>' },
 ];
 
 // Called by the demo.html frames loaded per theme to


### PR DESCRIPTION
Would like to merge for greater discoverability. Could you please let me know if I missed something in this pull request?

> [Atelier-Schemes](http://atelierbram.github.io/syntax-highlighting/atelier-schemes/) are colorschemes for many applications that come in a light - and in a dark background version. Generated with the help of [Base16-Builder](http://github.com/chriskempson/base16-builder).
