### PR TITLE
Don't highlight code-blocks with class lang-none.

### DIFF
--- a/src/prettify.js
+++ b/src/prettify.js
@@ -1270,6 +1270,15 @@ var prettyPrint;
     }
     return langHandlerRegistry[extension];
   }
+  // It would be silly to add prettyprint to something marked lang-none, but if
+  // some code does so carelessly, it's also silly to highlight it.
+  registerLangHandler(
+      createSimpleLexer(
+          [],
+          [
+           [PR_PLAIN, /^.+/],
+          ]),
+      ['none']);
   registerLangHandler(decorateSource, ['default-code']);
   registerLangHandler(
       createSimpleLexer(

--- a/tests/prettify_test_2.html
+++ b/tests/prettify_test_2.html
@@ -1065,6 +1065,17 @@ y=20;
 %}
 </pre>
 
+<h1>lang-none</h1>
+If code adds prettyprint to all the code-blocks, let's still respect lang-none.
+<pre id="lang-none" class="prettyprint lang-none">
+#! /bin/bash
+# toascii.sh
+for i in $(echo $* | fold -w 1);do
+  printf "%x " \'$i;
+done;
+echo
+</pre>
+
 </body>
 
 <script type="text/javascript">
@@ -2005,7 +2016,17 @@ var goldens = {
       '%%}`END`PLN\n' +
       '`END<span class="ident">y`END`PUN=`END`LIT20`END`PUN;`END`PLN\n' +
       '`END`COM%}`END'
-      )
+      ),
+      lang-none: (
+      '`PLN#! /bin/bash\n' +
+      '# toascii.sh\n' +
+      'for i in $(echo $*' +
+          ' | fold -w 1);' +
+          'do\n' +
+        '  printf "%x " \\\'$i;\n' +
+        'done;\n' +
+        'echo`END'
+      ),
 };
 </script>
 


### PR DESCRIPTION
Basically, this is a way of dealing sensibly with systems that correctly
allow users to mark the language of a code block as "lang-[whatever]",
but are overly aggressive in automatically adding the "prettyprint"
class to code blocks.