### PR TITLE
There is no \x class for the characters 0-9 and a-f.

### DIFF
--- a/src/lang-lasso.js
+++ b/src/lang-lasso.js
@@ -36,7 +36,7 @@ PR['registerLangHandler'](
           // ticked strings
           [PR['PR_STRING'],       /^\`[^\`]*(?:\`|$)/, null, '`'],
           // numeral as integer or hexidecimal
-          [PR['PR_LITERAL'],      /^0\x[\da-f]+|\d+/i, null, '0123456789'],
+          [PR['PR_LITERAL'],      /^0x[\da-f]+|\d+/i, null, '0123456789'],
           // local or thread variables, or hashbang
           [PR['PR_ATTRIB_NAME'],  /^#\d+|[#$][a-z_][\w.]*|#![ \S]+lasso9\b/i, null, '#$']
         ],

--- a/src/lang-rust.js
+++ b/src/lang-rust.js
@@ -35,11 +35,11 @@ PR['registerLangHandler'](
 		// Block comments (sadly I do not see how to make this cope with comment nesting as it should)
 		[PR['PR_COMMENT'], /^\/\*[\s\S]*?(?:\*\/|$)/],//, null],
 		// String and character literals
-		[PR['PR_STRING'], /^b"(?:[^\\]|\\(?:.|x\x\x))*?"/],  // Bytes literal
-		[PR['PR_STRING'], /^"(?:[^\\]|\\(?:.|x\x\x|u\{\x{1,6}\}))*?"/],  // String literal
+		[PR['PR_STRING'], /^b"(?:[^\\]|\\(?:.|x[\da-fA-F]{2}))*?"/],  // Bytes literal
+		[PR['PR_STRING'], /^"(?:[^\\]|\\(?:.|x[\da-fA-F]{2}|u\{\[\da-fA-F]{1,6}\}))*?"/],  // String literal
 		[PR['PR_STRING'], /^b?r(#*)\"[\s\S]*?\"\1/],  // Raw string/bytes literal
-		[PR['PR_STRING'], /^b'([^\\]|\\(.|x\x\x))'/],  // Byte literal
-		[PR['PR_STRING'], /^'([^\\]|\\(.|x\x\x|u\{\x{1,6}\}))'/],  // Character literal
+		[PR['PR_STRING'], /^b'([^\\]|\\(.|x[\da-fA-F]{2}))'/],  // Byte literal
+		[PR['PR_STRING'], /^'([^\\]|\\(.|x[\da-fA-F]{2}|u\{[\da-fA-F]{1,6}\}))'/],  // Character literal
 
 		// Lifetime
 		[PR['PR_TAG'], /^'\w+?\b/],


### PR DESCRIPTION
The sequence `\x##` is the placeholder for a char with the hex value of `##`,
where `#` stands for a hex digit, but this is not what we want here.
In this case we have to use `[\da-fA-F]` to match a hex digit.