### PR TITLE
Prefix all CSS selectors

### DIFF
--- a/src/prettify.css
+++ b/src/prettify.css
@@ -1,52 +1,57 @@
 /* Pretty printing styles. Used with prettify.js. */
 
 /* SPAN elements with the classes below are added by prettyprint. */
-.pln { color: #000 }  /* plain text */
+.prettyprint .pln { color: #000 }  /* plain text */
 
 @media screen {
-  .str { color: #080 }  /* string content */
-  .kwd { color: #008 }  /* a keyword */
-  .com { color: #800 }  /* a comment */
-  .typ { color: #606 }  /* a type name */
-  .lit { color: #066 }  /* a literal value */
+  .prettyprint .str { color: #080 }  /* string content */
+  .prettyprint .kwd { color: #008 }  /* a keyword */
+  .prettyprint .com { color: #800 }  /* a comment */
+  .prettyprint .typ { color: #606 }  /* a type name */
+  .prettyprint .lit { color: #066 }  /* a literal value */
   /* punctuation, lisp open bracket, lisp close bracket */
-  .pun, .opn, .clo { color: #660 }
-  .tag { color: #008 }  /* a markup tag name */
-  .atn { color: #606 }  /* a markup attribute name */
-  .atv { color: #080 }  /* a markup attribute value */
-  .dec, .var { color: #606 }  /* a declaration; a variable name */
-  .fun { color: red }  /* a function name */
+  .prettyprint .pun,
+  .prettyprint .opn,
+  .prettyprint .clo { color: #660 }
+  .prettyprint .tag { color: #008 }  /* a markup tag name */
+  .prettyprint .atn { color: #606 }  /* a markup attribute name */
+  .prettyprint .atv { color: #080 }  /* a markup attribute value */
+  .prettyprint .dec,
+  .prettyprint .var { color: #606 }  /* a declaration; a variable name */
+  .prettyprint .fun { color: red }  /* a function name */
 }
 
 /* Use higher contrast and text-weight for printable form. */
 @media print, projection {
-  .str { color: #060 }
-  .kwd { color: #006; font-weight: bold }
-  .com { color: #600; font-style: italic }
-  .typ { color: #404; font-weight: bold }
-  .lit { color: #044 }
-  .pun, .opn, .clo { color: #440 }
-  .tag { color: #006; font-weight: bold }
-  .atn { color: #404 }
-  .atv { color: #060 }
+  .prettyprint .str { color: #060 }
+  .prettyprint .kwd { color: #006; font-weight: bold }
+  .prettyprint .com { color: #600; font-style: italic }
+  .prettyprint .typ { color: #404; font-weight: bold }
+  .prettyprint .lit { color: #044 }
+  .prettyprint .pun,
+  .prettyprint .opn,
+  .prettyprint .clo { color: #440 }
+  .prettyprint .tag { color: #006; font-weight: bold }
+  .prettyprint .atn { color: #404 }
+  .prettyprint .atv { color: #060 }
 }
 
 /* Put a border around prettyprinted code snippets. */
 pre.prettyprint { padding: 2px; border: 1px solid #888 }
 
 /* Specify class=linenums on a pre to get line numbering */
-ol.linenums { margin-top: 0; margin-bottom: 0 } /* IE indents via margin-left */
-li.L0,
-li.L1,
-li.L2,
-li.L3,
-li.L5,
-li.L6,
-li.L7,
-li.L8 { list-style-type: none }
+.prettyprint ol.linenums { margin-top: 0; margin-bottom: 0 } /* IE indents via margin-left */
+.prettyprint li.L0,
+.prettyprint li.L1,
+.prettyprint li.L2,
+.prettyprint li.L3,
+.prettyprint li.L5,
+.prettyprint li.L6,
+.prettyprint li.L7,
+.prettyprint li.L8 { list-style-type: none }
 /* Alternate shading for lines */
-li.L1,
-li.L3,
-li.L5,
-li.L7,
-li.L9 { background: #eee }
+.prettyprint li.L1,
+.prettyprint li.L3,
+.prettyprint li.L5,
+.prettyprint li.L7,
+.prettyprint li.L9 { background: #eee }


### PR DESCRIPTION
Ensure that styles are only applied to the contents of `.prettyprint`.