### PR TITLE
Include JAVA_KEYWORDS in ALL_KEYWORDS

### DIFF
--- a/js-modules/prettify.js
+++ b/js-modules/prettify.js
@@ -136,8 +136,8 @@ var prettyPrint;
   var SH_KEYWORDS = [FLOW_CONTROL_KEYWORDS, "case,done,elif,esac,eval,fi," +
       "function,in,local,set,then,until"];
   var ALL_KEYWORDS = [
-      CPP_KEYWORDS, CSHARP_KEYWORDS, JSCRIPT_KEYWORDS, PERL_KEYWORDS,
-      PYTHON_KEYWORDS, RUBY_KEYWORDS, SH_KEYWORDS];
+      CPP_KEYWORDS, CSHARP_KEYWORDS, JAVA_KEYWORDS, JSCRIPT_KEYWORDS,
+      PERL_KEYWORDS, PYTHON_KEYWORDS, RUBY_KEYWORDS, SH_KEYWORDS];
   var C_TYPES = /^(DIR|FILE|vector|(de|priority_)?queue|list|stack|(const_)?iterator|(multi)?(set|map)|bitset|u?(int|float)\d*)\b/;
 
   // token style names.  correspond to css classes

--- a/src/prettify.js
+++ b/src/prettify.js
@@ -134,8 +134,8 @@ var prettyPrint;
   var SH_KEYWORDS = [FLOW_CONTROL_KEYWORDS, "case,done,elif,esac,eval,fi," +
       "function,in,local,set,then,until"];
   var ALL_KEYWORDS = [
-      CPP_KEYWORDS, CSHARP_KEYWORDS, JSCRIPT_KEYWORDS, PERL_KEYWORDS,
-      PYTHON_KEYWORDS, RUBY_KEYWORDS, SH_KEYWORDS];
+      CPP_KEYWORDS, CSHARP_KEYWORDS, JAVA_KEYWORDS, JSCRIPT_KEYWORDS,
+      PERL_KEYWORDS, PYTHON_KEYWORDS, RUBY_KEYWORDS, SH_KEYWORDS];
   var C_TYPES = /^(DIR|FILE|vector|(de|priority_)?queue|list|stack|(const_)?iterator|(multi)?(set|map)|bitset|u?(int|float)\d*)\b/;
 
   // token style names.  correspond to css classes

--- a/src/run_prettify.js
+++ b/src/run_prettify.js
@@ -359,8 +359,8 @@ var IN_GLOBAL_SCOPE = false;
       var SH_KEYWORDS = [FLOW_CONTROL_KEYWORDS, "case,done,elif,esac,eval,fi," +
           "function,in,local,set,then,until"];
       var ALL_KEYWORDS = [
-          CPP_KEYWORDS, CSHARP_KEYWORDS, JSCRIPT_KEYWORDS, PERL_KEYWORDS,
-          PYTHON_KEYWORDS, RUBY_KEYWORDS, SH_KEYWORDS];
+          CPP_KEYWORDS, CSHARP_KEYWORDS, JAVA_KEYWORDS, JSCRIPT_KEYWORDS,
+          PERL_KEYWORDS, PYTHON_KEYWORDS, RUBY_KEYWORDS, SH_KEYWORDS];
       var C_TYPES = /^(DIR|FILE|vector|(de|priority_)?queue|list|stack|(const_)?iterator|(multi)?(set|map)|bitset|u?(int|float)\d*)\b/;
     
       // token style names.  correspond to css classes

--- a/tests/prettify_test.html
+++ b/tests/prettify_test.html
@@ -1630,7 +1630,10 @@ var goldens = {
           '`PLN\n' +
       '      `END`PUN}`END`PLN\n' +
       '      `END`KWDpublic`END`PLN `END`KWDvoid`END' +
-          '`PLN remove`END`PUN()`END`PLN `END`PUN{`END`PLN `END`KWDthrow`END' +
+          // We incorrectly highlight the "remove" keyword here, though that's a keyword in
+          // C#, not Java. That's correct in the java_lang test-case below, where language
+          // is specified.
+          '`PLN `END`KWDremove`END`PUN()`END`PLN `END`PUN{`END`PLN `END`KWDthrow`END' +
           '`PLN `END`KWDnew`END`PLN `END' +
           '`TYPUnsupportedOperationException`END`PUN();`END`PLN `END' +
           '`PUN}`END`PLN\n' +


### PR DESCRIPTION
JAVA_KEYWORDS was inadvertently removed from ALL_KEYWORDS in d0fd4e3,
breaking several tests.

This also corrects a test to note a known bug. In the "java" test in
prettify_test.html, we incorrectly highlight "remove" as a keyword,
since that's a C# keyword and the language is not specified.

One preexisting test failure remains after this change: The "dart" test
in prettify_test.html fails due to 0dc62dc.