### PR TITLE
Support TypeScript, add more JS keywords.

### DIFF
--- a/src/prettify.js
+++ b/src/prettify.js
@@ -193,8 +193,9 @@ var prettyPrint;
       "for,if,in,is,isnt,loop,new,no,not,null,of,off,on,or,return,super,then," +
       "throw,true,try,unless,until,when,while,yes";
   var JSCRIPT_KEYWORDS = [COMMON_KEYWORDS,
-      "debugger,eval,export,function,get,instanceof,null,set,undefined," +
-      "var,with,Infinity,NaN"];
+      "abstract,async,await,constructor,debugger,enum,eval,export,function," +
+      "get,implements,instanceof,interface,let,null,set,undefined,var,with," +
+      "yield,Infinity,NaN"];
   var PERL_KEYWORDS = "caller,delete,die,do,dump,elsif,eval,exit,foreach,for," +
       "goto,if,import,last,local,my,next,no,our,print,package,redo,require," +
       "sub,undef,unless,until,use,wantarray,while,BEGIN,END";
@@ -1434,7 +1435,7 @@ var prettyPrint;
           'keywords': JSCRIPT_KEYWORDS,
           'cStyleComments': true,
           'regexLiterals': true
-        }), ['javascript', 'js']);
+        }), ['javascript', 'js', 'ts', 'typescript']);
   registerLangHandler(sourceDecorator({
           'keywords': COFFEE_KEYWORDS,
           'hashComments': 3,  // ### style block comments


### PR DESCRIPTION
This change adds several "newer" JavaScript keywords to the set of
supported keywords (let, yield, await).

"constructor" is the special name of an ES6 class constructor.

It also defines TypeScript as an alias of JavaScript. This is a bit of a
lie - TypeScript has some syntactical features that are not available in
JavaScript, such as interfaces, but for the most part it matches the
syntax exactly.

I've only added TS keywords that are or were reserved JS words
(abstract, interface, implements, enum) but left out other keywords
TypeScript defines (declare, namespace, module, any, number).

I'm happy to add those in case people think it's a good idea. I think it
would improve TypeScript formatting without inflicting much harm on JS
code.

Specs/references:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Keywords
https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#2.2.1