### PR TITLE
Instead of just removing an empty node, convert it to an '&nbsp' for …

### DIFF
--- a/src/run_prettify.js
+++ b/src/run_prettify.js
@@ -1349,7 +1349,7 @@ var IN_GLOBAL_SCOPE = false;
               breakAfter(node);
               if (!firstLine) {
                 // Don't leave blank text nodes in the DOM.
-                node.parentNode.removeChild(node);
+                node.parentNode.innerHTML = "&nbsp";
               }
             }
           }


### PR DESCRIPTION
…when dynamically prettifying code.

When prettifying code that has been dynamically inserted into the `<pre>` block when line numbering is enabled, blank lines (only consisting of a newline and/or carriage return) are erroneously removed from the DOM, when they should actually be preserved and converted into `&nbsp` elements to prevent browsers from not displaying them. Here is an example:

Original python script:
```python
# Script Name	: test.py
# Author		: Wheeler Law
# Created		: 2 March 2016
# Last Modified	: 
# Version		: 1.0

# Modifications	: 

# Description	: Sample python script to test the script uploader/syntax highlighter. 

import sys		# Import the Modules
import os		# Import the Modules

# Readfile Functions which open the file that is passed to the script

def readfile(filename):
	line = open(filename, 'r').read()
	print line

def main():
  if len(sys.argv) == 2:		# Check the arguments passed to the script
    filename = sys.argv[1]		# The filename is the first argument
    if not os.path.isfile(filename):	# Check the File exists
      print '[-] ' + filename + ' does not exist.'
      exit(0)
    if not os.access(filename, os.R_OK):	# Check you can read the file
      print '[-] ' + filename + ' access denied'
      exit(0)
  else:
    print '[-] Usage: ' + str(sys.argv[0]) + ' <filename>' # Print usage if not all parameters passed/Checked
    exit(0)
  print '[+] Reading from : ' + filename	# Display Message and read the file contents
  readfile(filename)
  
if __name__ == '__main__':
  main()
```

This is the output:

![image](https://cloud.githubusercontent.com/assets/3081566/13750197/03263402-e9ca-11e5-9d1f-10e71266280c.png)


You'll notice that the lines in the script that do not have any content in them are removed from the DOM, which causes inconsistencies with the line numbering. 
