### PR TITLE
Add support for Fortran

### DIFF
--- a/src/lang-fortran.js
+++ b/src/lang-fortran.js
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright (C) 2008 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview
+ * Registers a language handler for Fortran
+ *
+ * To use, include prettify.js and this file in your HTML page.
+ * Then put your code in an HTML tag like
+ *      <pre class="prettyprint lang-fortran">(fortran code)</pre>
+ *
+ * I used lang-lisp.js as a template and <a
+ * href="http://fortranwiki.org/fortran/show/Keywords">The Fortran
+ * Wiki</a> for the list of keywords
+ *
+ * Should work for the majority of Fortran versions
+ *
+ * @author zed.three@gmail.com
+ */
+
+PR['registerLangHandler'](
+    PR['createSimpleLexer'](
+        [
+            // A line comment that starts with !
+            [PR['PR_COMMENT'],     /^![^\r\n]*/, null, '!'],
+            // Whitespace
+            [PR['PR_PLAIN'],       /^[\t\n\r \xA0]+/, null, '\t\n\r \xA0'],
+            // Strings may use embedded double delimiters to represent
+            // a single character of that delimiter
+            [PR['PR_STRING'],      /^\"(?:([^\\"\r\n]|\"\")*\")/, null, '\"'],
+            [PR['PR_STRING'],      /^\'(?:([^\'\r\n]|\'\')*\')/, null, '\'']
+        ],
+        [
+            // Keywords from all versions of Fortran
+            [PR['PR_KEYWORD'], /^(?:abstract|allocatable|allocate|all *stop|assign|asynchronous|backspace|bind|call|case|class|close|codimension|common|contains|contiguous|continue|cycle|data|deallocate|deferred|dimension|do *,? *concurrent|elemental|entry|enumerator|equivalence|error stop|exit|extends|external|final|flush|format|generic|go *to|implicit|import|in *out|include|inquire|intent|intrinsic|lock|namelist|nopass|nullify|only|open|operator|optional|overridable|parameter|pass|pause|pointer|print|private|protected|public|pure|read|recursive|result|return|rewind|rewrite|non_save|sequence|stop|target|then|unlock|use|value|volatile|wait|where|while|write)\b/i],
+            // Block beginning/end statements (optional spaces)
+            [PR['PR_KEYWORD'], /^(?:end *)?(?:associate|block|block *data|critical|do|enum|file|forall|function|if|interface|module|procedure|program|select|submodule|subroutine|type|where)\b/i],
+            [PR['PR_KEYWORD'], /^(?:sync *)(?:all|images|memory)/i],
+            [PR['PR_KEYWORD'], /^(?:else *)(?:if|where)?/i],
+            // User defined .operators.
+            [PR['PR_KEYWORD'], /^\.\w*\./i],
+            [PR['PR_TYPE'], /^(?:character|complex|double *precision|integer|real|type)\b/i],
+            [PR['PR_LITERAL'], /^[+\-]?\.?\d+(?:\.\d*)?(?:[EeDd][+\-]?\d+)?/],
+            [PR['PR_PUNCTUATION'], /^[+\-/*=^&|<>%[\]()?:.,]/ ]
+        ]
+    ),
+    ['f', 'f90', 'F', 'F90', 'fortran']);

--- a/src/lang-fortran.js
+++ b/src/lang-fortran.js
@@ -54,6 +54,8 @@ PR['registerLangHandler'](
             [PR['PR_KEYWORD'], /^(?:end *)?(?:associate|block|block *data|critical|do|enum|file|forall|function|if|interface|module|procedure|program|select|submodule|subroutine|type|where)\b/i],
             [PR['PR_KEYWORD'], /^(?:sync *)(?:all|images|memory)/i],
             [PR['PR_KEYWORD'], /^(?:else *)(?:if|where)?/i],
+            // Boolean literals
+            [PR['PR_LITERAL'], /^\.(?:true|false)\./i],
             // User defined .operators.
             [PR['PR_KEYWORD'], /^\.\w*\./i],
             [PR['PR_TYPE'], /^(?:character|complex|double *precision|integer|real)\b/i],

--- a/src/lang-fortran.js
+++ b/src/lang-fortran.js
@@ -45,6 +45,9 @@ PR['registerLangHandler'](
             [PR['PR_STRING'],      /^\'(?:([^\'\r\n]|\'\')*\')/, null, '\'']
         ],
         [
+            // 'type(foo)' is a type
+            // 'type foo' is a keyword
+            [PR['PR_TYPE'], /^type *(?:\([^ \r\n]+\))/i],
             // Keywords from all versions of Fortran
             [PR['PR_KEYWORD'], /^(?:abstract|allocatable|allocate|all *stop|assign|asynchronous|backspace|bind|call|case|class|close|codimension|common|contains|contiguous|continue|cycle|data|deallocate|deferred|dimension|do *,? *concurrent|elemental|entry|enumerator|equivalence|error stop|exit|extends|external|final|flush|format|generic|go *to|implicit|import|in *out|include|inquire|intent|intrinsic|lock|namelist|nopass|nullify|only|open|operator|optional|overridable|parameter|pass|pause|pointer|print|private|protected|public|pure|read|recursive|result|return|rewind|rewrite|non_save|sequence|stop|target|then|unlock|use|value|volatile|wait|where|while|write)\b/i],
             // Block beginning/end statements (optional spaces)
@@ -53,7 +56,7 @@ PR['registerLangHandler'](
             [PR['PR_KEYWORD'], /^(?:else *)(?:if|where)?/i],
             // User defined .operators.
             [PR['PR_KEYWORD'], /^\.\w*\./i],
-            [PR['PR_TYPE'], /^(?:character|complex|double *precision|integer|real|type)\b/i],
+            [PR['PR_TYPE'], /^(?:character|complex|double *precision|integer|real)\b/i],
             [PR['PR_LITERAL'], /^[+\-]?\.?\d+(?:\.\d*)?(?:[EeDd][+\-]?\d+)?/],
             [PR['PR_PUNCTUATION'], /^[+\-/*=^&|<>%[\]()?:.,]/ ]
         ]

--- a/tests/prettify_test_2.html
+++ b/tests/prettify_test_2.html
@@ -12,6 +12,7 @@
       // Language extensions tested.
       "lang-clj.js",
       "lang-dart.js",
+      "lang-fortran.js",
       "lang-lisp.js",
       "lang-llvm.js",
       "lang-matlab.js",
@@ -1064,6 +1065,51 @@ x=10;
 %%}
 y=20;
 %}
+</pre>
+
+<h1>Fortran</h1>
+<pre class="prettyprint lang-f90" id="fortran">program foo
+  use, intrinsic :: iso_c_binding
+  implicit none
+  type, bind(C) :: ball
+    integer(kind=c_int) :: x
+    integer(kind=c_int) :: y
+    real(kind=c_float) :: mass
+  end type ball
+
+  integer, parameter :: foo = 12 ! inline comment
+  real bar = 4.0e0
+  complex, dimension(4, 5) :: zing
+  character(len=5), dimension(:), allocatable :: ding
+  ! In this context, 'type()' is a type, not a keyword
+  type(ball) :: football
+
+  football%x = foo
+
+  ! Allocate only if not allocated
+  if (.not. allocated(ding)) then
+    allocate(ding(12))
+  else
+    write(*,'(A)') 'can''t allocate ding: ding already allocated'
+  end if
+  ding(1) = "hello"
+  ding(2) = "world"
+  print*, ding(1), ", ", ding(2)
+contains
+  ! Fortran is not case-sensitive
+  FUNCTION HERP(A, B) RESULT(DERP)
+    INTEGER, INTENT(IN) :: A, B
+    INTEGER :: DERP
+    IF (A > B) THEN
+       DERP = A .MYOP. B
+    ! Some pairs of keywords may omit separating whitespace
+    ELSEIF (A < B) THEN
+      DERP = B .MYOP. A
+    ELSE
+      DERP = 0
+    ENDIF
+  END FUNCTION HERP
+ENDPROGRAM FOO
 </pre>
 
 </body>


### PR DESCRIPTION
Should work for most standard versions of Fortran, from 77 to 2008. Doesn't work so well for fixed-form source, e.g. "C" in the first column for comments.

Also, not sure how to generate the "correct" annotated output for the test case. Is there a tool in the repo?