### PR TITLE
add highlighting for Visual Basic for Applications

### DIFF
--- a/src/lang-vb.js
+++ b/src/lang-vb.js
@@ -64,4 +64,4 @@ PR['registerLangHandler'](
          // Square brackets
          [PR['PR_PUNCTUATION'], /^(?:\[|\])/]
         ]),
-    ['vb', 'vbs']);
+    ['vb', 'vbs', 'vba']);


### PR DESCRIPTION
could also consider adding .cls file extension (export of a VBA class object)