### PR TITLE
Download link 404

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -64,7 +64,7 @@ skin.
 ## Serving your own JS & CSS
 
 You can
-[download](https://raw.githubusercontent.com/google/code-prettify/master/distrib/prettify-small.tgz)
+[download](https://github.com/google/code-prettify/raw/master/distrib/prettify-small.zip)
 the scripts and styles and serve them yourself.  Make sure to include both the
 script and a stylesheet:
 


### PR DESCRIPTION
The current download link, linked to a `.tgz` file that no longer exists. This fixes it be pointing to the `.zip`