### PR TITLE
Added most commonly-used file extension for Kotlin

### DIFF
--- a/src/lang-kotlin.js
+++ b/src/lang-kotlin.js
@@ -55,4 +55,4 @@ PR['registerLangHandler'](
             // label definition
             [PR['PR_LITERAL'], /^[a-zA-Z0-9_]+@/]
         ]),
-    ['kotlin']);
+    ['kotlin', 'kt']);


### PR DESCRIPTION
It would be nice to resolve both variants
```
class="lang-kotlin"
```
and 
```
class="lang-kt"
```
as "kt" is most-commonly used file extension for Kotlin source code.