### PR TITLE
Make ol.linenums use display:inline-block

### DIFF
--- a/styles/desert.css
+++ b/styles/desert.css
@@ -14,7 +14,7 @@ pre .atv { color: #ffa0a0 } /* attribute value - pink */
 pre .dec { color: #98fb98 } /* decimal         - lightgreen */
 
 /* Specify class=linenums on a pre to get line numbering */
-ol.linenums { margin-top: 0; margin-bottom: 0; color: #AEAEAE } /* IE indents via margin-left */
+ol.linenums { margin-top: 0; margin-bottom: 0; color: #AEAEAE; display: inline-block; } /* IE indents via margin-left */
 li.L0,li.L1,li.L2,li.L3,li.L5,li.L6,li.L7,li.L8 { list-style-type: none }
 /* Alternate shading for lines */
 li.L1,li.L3,li.L5,li.L7,li.L9 { }

--- a/styles/doxy.css
+++ b/styles/doxy.css
@@ -41,7 +41,7 @@ pre.prettyprint a, code.prettyprint a {
    text-decoration:none;
 }
 /* Specify class=linenums on a pre to get line numbering; line numbers themselves are the same color as punctuation */
-ol.linenums { margin-top: 0; margin-bottom: 0; color: #8B8970; } /* IE indents via margin-left */
+ol.linenums { margin-top: 0; margin-bottom: 0; color: #8B8970; display: inline-block; } /* IE indents via margin-left */
 li.L0,li.L1,li.L2,li.L3,li.L5,li.L6,li.L7,li.L8 { list-style-type: none }
 /* Alternate shading for lines */
 li.L1,li.L3,li.L5,li.L7,li.L9 { }

--- a/styles/sons-of-obsidian.css
+++ b/styles/sons-of-obsidian.css
@@ -57,6 +57,7 @@ ol.linenums
 {
     margin-top: 0;
     margin-bottom: 0;
+    display: inline-block;
 }
 .prettyprint {
     background: #000;

--- a/styles/sunburst.css
+++ b/styles/sunburst.css
@@ -27,7 +27,7 @@ pre.prettyprint {
 
 
 /* Specify class=linenums on a pre to get line numbering */
-ol.linenums { margin-top: 0; margin-bottom: 0; color: #AEAEAE; } /* IE indents via margin-left */
+ol.linenums { margin-top: 0; margin-bottom: 0; color: #AEAEAE; display: inline-block; } /* IE indents via margin-left */
 li.L0,li.L1,li.L2,li.L3,li.L5,li.L6,li.L7,li.L8 { list-style-type: none }
 /* Alternate shading for lines */
 li.L1,li.L3,li.L5,li.L7,li.L9 { }


### PR DESCRIPTION
Without this, the ol.linenums section won't expand to
fill its pre parent if we set the parent to overflow:scroll.
This change fixes that bug.