### PR TITLE
Rust: Add missing dyn keyword, and add new reserved key word async, await and try

### DIFF
--- a/src/lang-rust.js
+++ b/src/lang-rust.js
@@ -46,7 +46,7 @@ PR['registerLangHandler'](
 
 		// Keywords, reserved keywords and primitive types
 		[PR['PR_KEYWORD'], /^(?:match|if|else|as|break|box|continue|extern|fn|for|in|if|impl|dyn|let|loop|pub|return|super|unsafe|where|while|use|mod|trait|struct|enum|type|move|mut|ref|static|const|crate)\b/],
-		[PR['PR_KEYWORD'], /^(?:alignof|become|do|offsetof|priv|pure|sizeof|typeof|unsized|yield|abstract|virtual|final|override|macro)\b/],
+		[PR['PR_KEYWORD'], /^(?:alignof|become|do|offsetof|priv|pure|sizeof|typeof|unsized|yield|async|await|try|abstract|virtual|final|override|macro)\b/],
 		[PR['PR_TYPE'], /^(?:[iu](8|16|32|64|128|size)|char|bool|f32|f64|str|Self)\b/],
 
 		// Rust 1.0 prelude items

--- a/src/lang-rust.js
+++ b/src/lang-rust.js
@@ -45,7 +45,7 @@ PR['registerLangHandler'](
 		[PR['PR_TAG'], /^'\w+?\b/],
 
 		// Keywords, reserved keywords and primitive types
-		[PR['PR_KEYWORD'], /^(?:match|if|else|as|break|box|continue|extern|fn|for|in|if|impl|let|loop|pub|return|super|unsafe|where|while|use|mod|trait|struct|enum|type|move|mut|ref|static|const|crate)\b/],
+		[PR['PR_KEYWORD'], /^(?:match|if|else|as|break|box|continue|extern|fn|for|in|if|impl|dyn|let|loop|pub|return|super|unsafe|where|while|use|mod|trait|struct|enum|type|move|mut|ref|static|const|crate)\b/],
 		[PR['PR_KEYWORD'], /^(?:alignof|become|do|offsetof|priv|pure|sizeof|typeof|unsized|yield|abstract|virtual|final|override|macro)\b/],
 		[PR['PR_TYPE'], /^(?:[iu](8|16|32|64|128|size)|char|bool|f32|f64|str|Self)\b/],
 


### PR DESCRIPTION
See, [2018-Specific Changes](https://doc.rust-lang.org/nightly/edition-guide/rust-2018/edition-changes.html#cargo) and [Keyword list](https://doc.rust-lang.org/reference/keywords.html):

- dyn is a strict keyword, in 2015 it is a weak keyword.
- async, await, and try are reserved keywords.